### PR TITLE
Add release with docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+# This file excludes paths from the Docker build context.
+#
+# By default, Docker's build context includes all files (and folders) in the
+# current directory. Even if a file isn't copied into the container it is still sent to
+# the Docker daemon.
+#
+# There are multiple reasons to exclude files from the build context:
+#
+# 1. Prevent nested folders from being copied into the container (ex: exclude
+#    /assets/node_modules when copying /assets)
+# 2. Reduce the size of the build context and improve build time (ex. /build, /deps, /doc)
+# 3. Avoid sending files containing sensitive information
+#
+# More information on using .dockerignore is available here:
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+.dockerignore
+
+# Ignore git, but keep git HEAD and refs to access current commit hash if needed:
+#
+# $ cat .git/HEAD | awk '{print ".git/"$2}' | xargs cat
+# d0b8727759e1e0e7aa3d41707d12376e373d5ecc
+.git
+!.git/HEAD
+!.git/refs
+
+# Common development/test artifacts
+/cover/
+/doc/
+/test/
+/tmp/
+.elixir_ls
+
+# Mix artifacts
+/_build/
+/deps/
+*.ez
+
+# Generated on crash by the VM
+erl_crash.dump
+
+# Static artifacts - These should be fetched and built inside the Docker image
+/assets/node_modules/
+/priv/static/assets/
+/priv/static/cache_manifest.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,8 @@ RUN mix deps.compile
 COPY priv priv
 COPY lib lib
 COPY --from=assets /app/assets ./assets/
-# compile assets
 RUN mix assets.deploy
-# Compile the release
 RUN mix compile
-# Changes to config/runtime.exs don't require recompiling the code
 COPY config/runtime.exs config/
 COPY rel rel
 RUN mix release
@@ -49,7 +46,6 @@ RUN apt-get update -y \
     tini \
   && apt-get clean \
   && rm -f /var/lib/apt/lists/*_*
-# Set the locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
   && locale-gen
 ENV LANG en_US.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,65 @@
+ARG ELIXIR_VERSION=1.17.3
+ARG OTP_VERSION=27.1.2
+ARG DEBIAN_VERSION=bookworm-20241016-slim
+ARG NODE_VERSION=23.0-bookworm-slim
+ARG ASSETS_IMAGE="node:${NODE_VERSION}"
+ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
+ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
+
+FROM ${ASSETS_IMAGE} AS assets
+WORKDIR /app/assets
+COPY assets .
+RUN npm install
+
+FROM ${BUILDER_IMAGE} AS builder
+RUN apt-get update -y \
+  && apt-get install -y \
+    build-essential \
+    git \
+  && apt-get clean \
+  && rm -f /var/lib/apt/lists/*_*
+WORKDIR /app
+RUN mix do local.hex --force, local.rebar --force
+ARG MIX_ENV="prod"
+ENV MIX_ENV=${MIX_ENV}
+COPY mix.exs mix.lock ./
+RUN mix deps.get --only $MIX_ENV
+RUN mkdir config
+COPY config/config.exs config/${MIX_ENV}.exs config/
+RUN mix deps.compile
+COPY priv priv
+COPY lib lib
+COPY --from=assets /app/assets ./assets/
+# compile assets
+RUN mix assets.deploy
+# Compile the release
+RUN mix compile
+# Changes to config/runtime.exs don't require recompiling the code
+COPY config/runtime.exs config/
+COPY rel rel
+RUN mix release
+
+FROM ${RUNNER_IMAGE}
+RUN apt-get update -y \
+  && apt-get install -y \
+    libncurses5 \
+    libstdc++6 \
+    locales ca-certificates \
+    openssl \
+    tini \
+  && apt-get clean \
+  && rm -f /var/lib/apt/lists/*_*
+# Set the locale
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
+  && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+WORKDIR /app
+RUN chown nobody /app
+ARG MIX_ENV="prod"
+ENV MIX_ENV=${MIX_ENV}
+COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/growth ./
+USER nobody
+ENTRYPOINT ["tini", "-s", "--"]
+CMD ["/app/bin/server"]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -34,12 +34,14 @@ if config_env() == :prod do
       """
 
   host = System.get_env("PHX_HOST") || "example.com"
+  host_port = System.get_env("PHX_PORT") || "443"
+  host_scheme = System.get_env("PHX_SCHEME") || "https"
   port = String.to_integer(System.get_env("PORT") || "4000")
 
   config :growth, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
   config :growth, GrowthWeb.Endpoint,
-    url: [host: host, port: 443, scheme: "https"],
+    url: [host: host, port: host_port, scheme: host_scheme],
     http: [
       # Enable IPv6 and bind on all interfaces.
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,3 @@ services:
       PHX_HOST: '${GROWTH_PHX_HOST:-127.0.0.1}'
       PHX_PORT: '${GROWTH_PHX_PORT:-4000}'
       PHX_SCHEME: '${GROWTH_PHX_SCHEME:-http}'
-    ports:
-      - '${GROWTH_PORT:-4000}:4000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+---
+services:
+  growth:
+    image: 'anadubas/growth:${GROWTH_TAG:-dev}'
+    build: .
+    pull_policy: never
+    init: true
+    hostname: growth
+    restart: unless-stopped
+    environment:
+      SECRET_KEY_BASE: '${GROWTH_SECRET_KEY_BASE:-mVrA1wyJvtAVp0hIgT2DnZMfyWh5dPltmEUWYVXN2yp8O742eTeL7sEe4NH9pskF}'
+      PHX_HOST: '${GROWTH_PHX_HOST:-127.0.0.1}'
+      PHX_PORT: '${GROWTH_PHX_PORT:-4000}'
+      PHX_SCHEME: '${GROWTH_PHX_SCHEME:-http}'
+    ports:
+      - '${GROWTH_PORT:-4000}:4000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@ services:
     init: true
     hostname: growth
     restart: unless-stopped
+    develop:
+      watch:
+        - path: ./
+          action: rebuild
     environment:
       SECRET_KEY_BASE: '${GROWTH_SECRET_KEY_BASE:-mVrA1wyJvtAVp0hIgT2DnZMfyWh5dPltmEUWYVXN2yp8O742eTeL7sEe4NH9pskF}'
       PHX_HOST: '${GROWTH_PHX_HOST:-127.0.0.1}'

--- a/lib/growth/load_reference.ex
+++ b/lib/growth/load_reference.ex
@@ -15,7 +15,7 @@ defmodule Growth.LoadReference do
         {:error, "Invalid data type: #{data_type}"}
 
       file_name ->
-        file_path = "priv/indicators/" <> file_name
+        file_path = Application.app_dir(:growth, "priv/indicators") <> "/#{file_name}"
         CSVLoader.load_csv_data(file_path)
     end
   end

--- a/lib/growth/load_reference.ex
+++ b/lib/growth/load_reference.ex
@@ -15,8 +15,10 @@ defmodule Growth.LoadReference do
         {:error, "Invalid data type: #{data_type}"}
 
       file_name ->
-        file_path = Application.app_dir(:growth, "priv/indicators") <> "/#{file_name}"
-        CSVLoader.load_csv_data(file_path)
+        :growth
+        |> Application.app_dir(["priv", "indicators"])
+        |> Path.join(file_name)
+        |> CSVLoader.load_csv_data()
     end
   end
 end

--- a/rel/overlays/bin/server
+++ b/rel/overlays/bin/server
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+cd -P -- "$(dirname -- "$0")"
+PHX_SERVER=true exec ./growth start

--- a/rel/overlays/bin/server.bat
+++ b/rel/overlays/bin/server.bat
@@ -1,0 +1,2 @@
+set PHX_SERVER=true
+call "%~dp0\growth" start


### PR DESCRIPTION
Configure application release to execute the project in a remote server or locally through `docker`.

To make local execution easier, I added the `docker-compose` definition.

Also, fixed an issue to access the `priv` path in the released application by using [`Application.app_dir/2`](https://hexdocs.pm/elixir/1.17.3/Application.html#app_dir/2).