### PR TITLE
fix: use dialyxir only on tests and without runtime

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Growth.MixProject do
       {:bandit, "~> 1.5"},
       {:credo, "~> 1.7.10"},
       {:dns_cluster, "~> 0.1.1"},
-      {:dialyxir, "~> 1.4.5"},
+      {:dialyxir, "~> 1.4.5", only: :test, runtime: false},
       {:esbuild, "~> 0.8", runtime: Mix.env() == :dev},
       {:finch, "~> 0.13"},
       {:floki, ">= 0.30.0", only: :test},


### PR DESCRIPTION
Remove the following warning when starting the server:

```
Warning: the `dialyxir` application's start function was called, which likely means you
did not add the dependency with the `runtime: false` flag. This is not recommended because
it will mean that unnecessary applications are started, and unnecessary applications are most
likely being added to your PLT file, increasing build time.
Please add `runtime: false` in your `mix.exs` dependency section e.g.:
{:dialyxir, "~> 0.5", only: [:dev], runtime: false}
```