### PR TITLE
fix(csv): call `Application.app_dir/2` at runtime

### DIFF
--- a/lib/growth/csv_loader.ex
+++ b/lib/growth/csv_loader.ex
@@ -22,8 +22,6 @@ defmodule Growth.CSVLoader do
   use GenServer
   alias NimbleCSV.RFC4180, as: CSV
 
-  @data_dir Application.app_dir(:growth, ["priv", "indicators"])
-
   @mapping %{
     "weight_for_age.csv" => :weight,
     "height_for_age.csv" => :height,
@@ -53,7 +51,10 @@ defmodule Growth.CSVLoader do
   end
 
   defp load_all do
-    Path.wildcard(Path.join(@data_dir, "*.csv"))
+    :growth
+    |> Application.app_dir(["priv", "indicators"])
+    |> Path.join("*.csv")
+    |> Path.wildcard()
     |> Enum.each(&load_csv_to_ets/1)
   end
 


### PR DESCRIPTION
Currently, the service is throwing errors because the `ets` tables aren't available.

These errors happen because the `priv` folder changes between the `builder` stage and the final one in the `Dockerfile.

Comparing both calls, the system returns the following paths:

* compile time: `/app/_build/prod/lib/growth/priv/indicators`
* runtime: `/app/lib/growth-0.1.0/priv/indicators`

To fix this issue, the system now gets the reference to the `priv` dir inside the function needing it.