### PR TITLE
fix: avoid error for missing results

### DIFF
--- a/lib/growth/calculate.ex
+++ b/lib/growth/calculate.ex
@@ -15,6 +15,7 @@ defmodule Growth.Calculate do
   alias Growth.LoadReference
   alias Growth.Measure
   alias Growth.Percentile
+  alias Growth.Result
   alias Growth.Zscore
 
   @days_in_month 30.4375
@@ -99,10 +100,10 @@ defmodule Growth.Calculate do
          %{
            age_in_months: child.age_in_months,
            gender: child.gender,
-           has_bmi_result: bmi_result != "no results",
-           has_head_circumference_result: head_circumference_result != "no results",
-           has_height_result: height_result != "no results",
-           has_weight_result: weight_result != "no results",
+           has_bmi_result: bmi_result.available?,
+           has_head_circumference_result: head_circumference_result.available?,
+           has_height_result: height_result.available?,
+           has_weight_result: weight_result.available?,
            measure_date: child.measure_date,
            success: true
          }}
@@ -120,10 +121,9 @@ defmodule Growth.Calculate do
     - `gender`: The child's gender.
 
   ## Returns
-    - A map containing Z-scores, percentiles, and standard deviation values.
-    - If no data is found, returns the string "no results".
+    - A result struct
   """
-  @spec calculate_result(number(), atom(), Child.t()) :: map() | String.t()
+  @spec calculate_result(number(), atom(), Child.t()) :: Result.t()
   def calculate_result(measure, data_type, %Child{} = child)
       when is_number(measure) do
     :telemetry.span(
@@ -143,6 +143,7 @@ defmodule Growth.Calculate do
               |> add_percentile()
               |> add_classification(data_type)
               |> format_result()
+              |> then(&Result.new(true, &1))
 
             {result,
              %{
@@ -154,7 +155,7 @@ defmodule Growth.Calculate do
              }}
 
           {:error, _} ->
-            {"no data found",
+            {Result.new(false, %{}),
              %{
                age_in_months: child.age_in_months,
                data_type: data_type,
@@ -167,7 +168,7 @@ defmodule Growth.Calculate do
     )
   end
 
-  def calculate_result(_measure, _data_type, _child), do: "no results"
+  def calculate_result(_measure, _data_type, _child), do: Result.new(false, %{})
 
   defp add_zscore(%{l: l, m: m, s: s} = data, measure) do
     zscore = Zscore.calculate(measure, l, m, s)

--- a/lib/growth/calculate.ex
+++ b/lib/growth/calculate.ex
@@ -86,14 +86,14 @@ defmodule Growth.Calculate do
         head_circumference_result =
           calculate_result(head_circumference, :head_circumference, child)
 
-        result = %{
-          weight_result: weight_result,
-          height_result: height_result,
-          head_circumference_result: head_circumference_result,
-          bmi_result: bmi_result
+        results = %{
+          weight: weight_result,
+          height: height_result,
+          head_circumference: head_circumference_result,
+          bmi: bmi_result
         }
 
-        measure = %Measure{growth | results: result}
+        measure = %Measure{growth | results: results}
 
         {measure, %{count: 1},
          %{
@@ -108,16 +108,6 @@ defmodule Growth.Calculate do
          }}
       end
     )
-
-    %Measure{
-      growth
-      | results: %{
-          weight: calculate_result(weight, :weight, child),
-          height: calculate_result(height, :height, child),
-          head_circumference: calculate_result(head_circumference, :head_circumference, child),
-          bmi: calculate_result(bmi, :bmi, child)
-        }
-    }
   end
 
   @doc """

--- a/lib/growth/result.ex
+++ b/lib/growth/result.ex
@@ -1,0 +1,41 @@
+defmodule Growth.Result do
+  @moduledoc false
+  @type null_number() :: number() | nil
+  @type null_non_neg_number() :: number() | nil
+  @type t() :: %__MODULE__{
+          sd3neg: null_non_neg_number(),
+          sd2neg: null_non_neg_number(),
+          sd1neg: null_non_neg_number(),
+          sd0: null_non_neg_number(),
+          sd1: null_non_neg_number(),
+          sd2: null_non_neg_number(),
+          sd3: null_non_neg_number(),
+          zscore: null_number(),
+          percentile: null_non_neg_number(),
+          classification: String.t() | nil
+        }
+  defstruct [
+    :sd3neg,
+    :sd2neg,
+    :sd1neg,
+    :sd0,
+    :sd1,
+    :sd2,
+    :sd3,
+    :zscore,
+    :percentile,
+    :classification,
+    :available?
+  ]
+
+  @spec new(boolean(), map()) :: t()
+  def new(false, _) do
+    %__MODULE__{available?: false}
+  end
+
+  def new(true, params) do
+    __MODULE__
+    |> struct(params)
+    |> Map.put(:available?, true)
+  end
+end

--- a/lib/growth/result.ex
+++ b/lib/growth/result.ex
@@ -1,5 +1,11 @@
 defmodule Growth.Result do
-  @moduledoc false
+  @moduledoc """
+  Represents a result for a given measurement of a child, such as weight, height, etc.
+
+  This holds the `zscore` and `percentile` wich allow one to compare how this measurement fits agagainst common patterns. As well as, have a `classification` that summarizes this comparison.
+
+  To help knowing if the result is available or not, the `available?` field is set, so any consumer is aware if this result is not available, due to missing measurement value or missing classification data.
+  """
   @type null_number() :: number() | nil
   @type null_non_neg_number() :: number() | nil
   @type t() :: %__MODULE__{
@@ -29,6 +35,9 @@ defmodule Growth.Result do
     :available?
   ]
 
+  @doc """
+  Create a new result based on the availability of data and the data itself.
+  """
   @spec new(boolean(), map()) :: t()
   def new(false, _) do
     %__MODULE__{available?: false}

--- a/lib/growth/result.ex
+++ b/lib/growth/result.ex
@@ -12,7 +12,8 @@ defmodule Growth.Result do
           sd3: null_non_neg_number(),
           zscore: null_number(),
           percentile: null_non_neg_number(),
-          classification: String.t() | nil
+          classification: String.t() | nil,
+          available?: boolean()
         }
   defstruct [
     :sd3neg,

--- a/lib/growth_web/live/growth_live.ex
+++ b/lib/growth_web/live/growth_live.ex
@@ -107,26 +107,30 @@ defmodule GrowthWeb.GrowthLive do
   defp default_child, do: %Child{name: "", gender: "", birthday: Date.utc_today()}
 
   defp build_all_charts(%Measure{} = measure) do
-    height = build_chart_data(:height, measure.child, measure.height)
-    weight = build_chart_data(:weight, measure.child, measure.weight)
-    bmi = build_chart_data(:bmi, measure.child, measure.bmi)
-    hc = build_chart_data(:head_circumference, measure.child, measure.head_circumference)
+    height = build_chart_data(:height, measure)
+    weight = build_chart_data(:weight, measure)
+    bmi = build_chart_data(:bmi, measure)
+    head_circumference = build_chart_data(:head_circumference, measure)
 
     %{
       height: height,
       weight: weight,
       bmi: bmi,
-      head_circ: hc
+      head_circ: head_circumference
     }
   end
 
   defp build_chart_data(
          type,
-         %Child{gender: gender, age_in_months: reference_age_in_months},
-         value
+         %Measure{
+           child: %Child{gender: gender, age_in_months: reference_age_in_months},
+           results: results
+         } = measure
        ) do
     age_range_in_months = 5
     age_subdivisions = 10
+
+    value = Map.get(measure, type)
 
     default_data = %{
       child: [%{x: reference_age_in_months, y: value}],
@@ -140,27 +144,31 @@ defmodule GrowthWeb.GrowthLive do
       sd0: []
     }
 
-    case LoadReferenceChart.load_data(
-           type,
-           gender,
-           reference_age_in_months,
-           age_range_in_months,
-           age_subdivisions
-         ) do
-      {:ok, data} ->
-        Enum.reduce(data, default_data, fn point, acc ->
-          %{
-            acc
-            | labels: [point.age | acc.labels],
-              sd3neg: [%{x: point.age, y: point.sd3neg} | acc.sd3neg],
-              sd2neg: [%{x: point.age, y: point.sd2neg} | acc.sd2neg],
-              sd1neg: [%{x: point.age, y: point.sd1neg} | acc.sd1neg],
-              sd0: [%{x: point.age, y: point.sd0} | acc.sd0],
-              sd1: [%{x: point.age, y: point.sd1} | acc.sd1],
-              sd2: [%{x: point.age, y: point.sd2} | acc.sd2],
-              sd3: [%{x: point.age, y: point.sd3} | acc.sd3]
-          }
-        end)
+    with true <- results |> Map.get(type, %{}) |> Map.get(:available?, false),
+         {:ok, data} <-
+           LoadReferenceChart.load_data(
+             type,
+             gender,
+             reference_age_in_months,
+             age_range_in_months,
+             age_subdivisions
+           ) do
+      Enum.reduce(data, default_data, fn point, acc ->
+        %{
+          acc
+          | labels: [point.age | acc.labels],
+            sd3neg: [%{x: point.age, y: point.sd3neg} | acc.sd3neg],
+            sd2neg: [%{x: point.age, y: point.sd2neg} | acc.sd2neg],
+            sd1neg: [%{x: point.age, y: point.sd1neg} | acc.sd1neg],
+            sd0: [%{x: point.age, y: point.sd0} | acc.sd0],
+            sd1: [%{x: point.age, y: point.sd1} | acc.sd1],
+            sd2: [%{x: point.age, y: point.sd2} | acc.sd2],
+            sd3: [%{x: point.age, y: point.sd3} | acc.sd3]
+        }
+      end)
+    else
+      false ->
+        default_data
 
       {:error, _} ->
         default_data

--- a/lib/growth_web/live/growth_live.ex
+++ b/lib/growth_web/live/growth_live.ex
@@ -116,7 +116,7 @@ defmodule GrowthWeb.GrowthLive do
       height: height,
       weight: weight,
       bmi: bmi,
-      head_circ: head_circumference
+      head_circumference: head_circumference
     }
   end
 

--- a/lib/growth_web/live/results_component.ex
+++ b/lib/growth_web/live/results_component.ex
@@ -121,4 +121,8 @@ defmodule GrowthWeb.ResultsComponent do
   defp format_score(score) when is_number(score) do
     Float.round(score / 1, 2)
   end
+
+  defp format_score(nil) do
+    "---"
+  end
 end

--- a/lib/growth_web/live/results_component.ex
+++ b/lib/growth_web/live/results_component.ex
@@ -42,62 +42,49 @@ defmodule GrowthWeb.ResultsComponent do
         <h2 class="text-lg font-bold mb-4">Resultados</h2>
 
         <div class="grid grid-cols-2 gap-4">
-          <%= for {label, result} <- [
-            {"Altura", @measure.results.height},
-            {"Peso", @measure.results.weight},
-            {"IMC", @measure.results.bmi},
-            {"Perímetro Cefálico", @measure.results.head_circumference}
+          <%= for {label, key} <- [
+            {"Altura", :height},
+            {"Peso", :weight},
+            {"IMC", :bmi},
+            {"Perímetro Cefálico", :head_circumference}
           ] do %>
+            <% result = @measure.results[key] %>
             <div class="card bg-base-200 rounded-box p-3">
-              <p><strong>{label}:</strong> {result_from_label(@measure, label)}</p>
-              <p><strong>Percentil:</strong> {format_score(result.percentile)}%</p>
-              <p><strong>Z-score:</strong> {format_score(result.zscore)}</p>
+              <p><strong>{label}:</strong> {format_score(Map.get(@measure, key))}</p>
+              <%= if result.available? do %>
+                <p><strong>Percentil:</strong> {format_score(result.percentile)}%</p>
+                <p><strong>Z-score:</strong> {format_score(result.zscore)}</p>
+              <% else %>
+                <p class="text-sm text-error"><em>Indisponível para a idade</em></p>
+              <% end %>
             </div>
           <% end %>
         </div>
       </div>
 
-      <div class="card w-full mx-auto bg-base-300 shadow-md rounded-lg p-6">
-        <div class="w-full text-center mb-4">
-          <h3 class="text-lg font-bold">Altura / Idade</h3>
-          <canvas
-            id="chart-height"
-            class="w-full h-96"
-            phx-hook="GrowthChart"
-            data-chart={Jason.encode!(@charts.height)}
-          ></canvas>
+      <%= if any_result_available?(@measure.results) do %>
+        <div class="card w-full mx-auto bg-base-300 shadow-md rounded-lg p-6">
+          <%= for {title, chart_id, key} <- [
+            {"Altura / Idade", "chart-height", :height},
+            {"Peso / Idade", "chart-weight", :weight},
+            {"IMC / Idade", "chart-bmi", :bmi},
+            {"Perímetro Cefálico / Idade", "chart-hc", :head_circumference}
+          ] do %>
+            <% result = @measure.results[key] %>
+            <%= if result.available? do %>
+              <div class="w-full text-center mb-4">
+                <h3 class="text-lg font-bold">{title}</h3>
+                <canvas
+                  id={chart_id}
+                  class="w-full h-96"
+                  phx-hook="GrowthChart"
+                  data-chart={Jason.encode!(@charts[key])}
+                ></canvas>
+              </div>
+            <% end %>
+          <% end %>
         </div>
-
-        <div class="w-full text-center mb-4">
-          <h3 class="text-lg font-bold">Peso / Idade</h3>
-          <canvas
-            id="chart-weight"
-            class="w-full h-96"
-            phx-hook="GrowthChart"
-            data-chart={Jason.encode!(@charts.weight)}
-          ></canvas>
-        </div>
-
-        <div class="w-full text-center mb-4">
-          <h3 class="text-lg font-bold">IMC / Idade</h3>
-          <canvas
-            id="chart-bmi"
-            class="w-full h-96"
-            phx-hook="GrowthChart"
-            data-chart={Jason.encode!(@charts.bmi)}
-          ></canvas>
-        </div>
-
-        <div class="w-full text-center mb-4">
-          <h3 class="text-lg font-bold">Perímetro Cefálico / Idade</h3>
-          <canvas
-            id="chart-hc"
-            class="w-full h-96"
-            phx-hook="GrowthChart"
-            data-chart={Jason.encode!(@charts.head_circ)}
-          ></canvas>
-        </div>
-      </div>
+      <% end %>
 
       <div class="text-center">
         <.button id="reset-btn" class="btn btn-primary" phx-click="reset">Reiniciar</.button>
@@ -106,16 +93,8 @@ defmodule GrowthWeb.ResultsComponent do
     """
   end
 
-  defp result_from_label(measure, label) do
-    %{
-      "Altura" => :height,
-      "Peso" => :weight,
-      "IMC" => :bmi,
-      "Perímetro Cefálico" => :head_circumference
-    }
-    |> Map.get(label)
-    |> then(&Map.get(measure, &1))
-    |> format_score()
+  defp any_result_available?(results) do
+    Enum.any?(results, fn {_key, result} -> result.available? end)
   end
 
   defp format_score(score) when is_number(score) do

--- a/test/growth/calculate_test.exs
+++ b/test/growth/calculate_test.exs
@@ -20,35 +20,37 @@ defmodule Growth.CalculateTest do
     end
   end
 
-  test "returns a Measure struct with results" do
-    child = %Child{
-      name: "Joana",
-      birthday: ~D[2022-01-01],
-      gender: "female",
-      measure_date: ~D[2024-01-01],
-      age_in_months: Calculate.age_in_months(~D[2022-01-01], ~D[2024-01-01]),
-      age_in_decimal: Calculate.in_months_decimal(~D[2022-01-01], ~D[2024-01-01])
-    }
+  describe "calculate" do
+    test "returns a Measure struct with results" do
+      child = %Child{
+        name: "Joana",
+        birthday: ~D[2022-01-01],
+        gender: "female",
+        measure_date: ~D[2024-01-01],
+        age_in_months: Calculate.age_in_months(~D[2022-01-01], ~D[2024-01-01]),
+        age_in_decimal: Calculate.in_months_decimal(~D[2022-01-01], ~D[2024-01-01])
+      }
 
-    measure = %Measure{
-      weight: 12.8,
-      height: 88.7,
-      head_circumference: 47.0,
-      bmi: 16.27,
-      child: child
-    }
+      measure = %Measure{
+        weight: 12.8,
+        height: 88.7,
+        head_circumference: 47.0,
+        bmi: 16.27,
+        child: child
+      }
 
-    result = Calculate.results(measure, child)
+      result = Calculate.results(measure, child)
 
-    assert is_map(result.results)
-    assert_in_delta result.results.bmi[:zscore], 0.6038, 0.0001
-    assert_in_delta result.results.weight[:percentile], 84.40, 0.01
-    assert result.results.height[:sd1neg] == 82.3
-    assert result.results.head_circumference[:sd3] == 51.2
+      assert is_map(result.results)
+      assert_in_delta result.results.bmi.zscore, 0.6038, 0.0001
+      assert_in_delta result.results.weight.percentile, 84.40, 0.01
+      assert result.results.height.sd1neg == 82.3
+      assert result.results.head_circumference.sd3 == 51.2
+    end
   end
 
-  describe "calculate_result/3 fallback" do
-    test "returns 'no results' when measurement is not numeric" do
+  describe "calculate_result/3" do
+    test "returns unavailable result when measurement is not numeric" do
       result =
         Calculate.calculate_result("invalid", :weight, %Child{
           age_in_months: 24,
@@ -57,7 +59,7 @@ defmodule Growth.CalculateTest do
           name: "A"
         })
 
-      assert result == "no results"
+      refute result.available?
     end
   end
 end

--- a/test/growth/calculate_test.exs
+++ b/test/growth/calculate_test.exs
@@ -47,6 +47,90 @@ defmodule Growth.CalculateTest do
       assert result.results.height.sd1neg == 82.3
       assert result.results.head_circumference.sd3 == 51.2
     end
+
+    test "returns a Measure struct with results for age greater than 5 years" do
+      birthday = ~D[2021-01-16]
+      measure_date = ~D[2026-07-16]
+
+      child =
+        %Child{
+          name: "Jane",
+          birthday: birthday,
+          gender: "female",
+          measure_date: measure_date,
+          age_in_months: Calculate.age_in_months(birthday, measure_date),
+          age_in_decimal: Calculate.in_months_decimal(birthday, measure_date)
+        }
+
+      measure =
+        %Measure{
+          weight: 19.0,
+          height: 112.0,
+          head_circumference: 43.0,
+          bmi: 15.15,
+          child: child
+        }
+
+      result = Calculate.results(measure, child)
+
+      assert is_map(result.results)
+      assert_in_delta result.results.bmi.zscore, -0.06335, 0.00001
+      assert_in_delta result.results.weight.percentile, 50.66, 0.001
+      assert result.results.height.sd1neg == 106.767
+      refute result.results.head_circumference.available?
+    end
+
+    test "returns a Measure struct with results for age greater than 10 years" do
+      birthday = ~D[2016-01-16]
+      measure_date = ~D[2026-07-16]
+
+      child =
+        %Child{
+          name: "Jane",
+          birthday: birthday,
+          gender: "female",
+          measure_date: measure_date,
+          age_in_months: Calculate.age_in_months(birthday, measure_date),
+          age_in_decimal: Calculate.in_months_decimal(birthday, measure_date)
+        }
+
+      measure =
+        %Measure{weight: 33.3, height: 141.3, head_circumference: 45.0, bmi: 16.68, child: child}
+
+      result = Calculate.results(measure, child)
+
+      assert is_map(result.results)
+      assert_in_delta result.results.bmi.zscore, -0.08725, 0.00001
+      assert result.results.height.sd1neg == 134.754
+      refute result.results.weight.available?
+      refute result.results.head_circumference.available?
+    end
+
+    test "returs a Measure struct with results for age around 19 years" do
+      birthday = ~D[2007-07-16]
+      measure_date = ~D[2026-07-16]
+
+      child =
+        %Child{
+          name: "Jane",
+          birthday: birthday,
+          gender: "female",
+          measure_date: measure_date,
+          age_in_months: Calculate.age_in_months(birthday, measure_date),
+          age_in_decimal: Calculate.in_months_decimal(birthday, measure_date)
+        }
+
+      measure =
+        %Measure{weight: 57.26, height: 163.2, head_circumference: 45.0, bmi: 21.49, child: child}
+
+      result = Calculate.results(measure, child)
+
+      assert is_map(result.results)
+      assert_in_delta result.results.bmi.zscore, 0.02034, 0.000001
+      assert result.results.height.sd1neg == 156.614
+      refute result.results.weight.available?
+      refute result.results.head_circumference.available?
+    end
   end
 
   describe "calculate_result/3" do

--- a/test/growth/calculate_test.exs
+++ b/test/growth/calculate_test.exs
@@ -106,7 +106,7 @@ defmodule Growth.CalculateTest do
       refute result.results.head_circumference.available?
     end
 
-    test "returs a Measure struct with results for age around 19 years" do
+    test "returns a Measure struct with results for age around 19 years" do
       birthday = ~D[2007-07-16]
       measure_date = ~D[2026-07-16]
 

--- a/test/growth_web/live/growth_live_test.exs
+++ b/test/growth_web/live/growth_live_test.exs
@@ -39,10 +39,8 @@ defmodule GrowthWeb.GrowthLiveTest do
 
       assert has_element?(view, "#child-form")
       refute has_element?(view, "#measure-form")
-
       assert has_element?(view, ~s|#child-form input[name="child[name]"][value="Jane Doe"]|)
-
-      expected_birthday = Date.to_iso8601(Date.add(Date.utc_today(), -365 * 2))
+      expected_birthday = birthday_months_ago(24)
       assert html =~ ~s|value="#{expected_birthday}"|
     end
   end
@@ -118,11 +116,13 @@ defmodule GrowthWeb.GrowthLiveTest do
   describe "save_measure" do
     test "advances to results step with populated chart data", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/")
+
       advance_to_measure_step(view)
 
-      view
-      |> form("#measure-form", measure: valid_measure_attrs())
-      |> render_submit()
+      html =
+        view
+        |> form("#measure-form", measure: valid_measure_attrs())
+        |> render_submit()
 
       assert has_element?(view, "#chart-height")
       assert has_element?(view, "#chart-weight")
@@ -145,12 +145,16 @@ defmodule GrowthWeb.GrowthLiveTest do
           assert Map.has_key?(chart, key), "chart #{id} missing key #{inspect(key)}"
         end
       end
+
+      # Every indicator is available for a 2-year-old, so no note is shown.
+      refute html =~ "Indisponível"
     end
 
     test "stays on measure step and renders error when height is negative", %{
       conn: conn
     } do
       {:ok, view, _html} = live(conn, ~p"/")
+
       advance_to_measure_step(view)
 
       view
@@ -164,26 +168,46 @@ defmodule GrowthWeb.GrowthLiveTest do
       assert render(view) =~ "too small: must be at least 0"
     end
 
-    test "over 60 months renders with head circumference unavailable", %{conn: conn} do
-      assert_renders_for_age(conn, 90,
-        available: ~w(chart-height chart-weight chart-bmi),
-        unavailable: ~w(chart-hc)
-      )
-    end
+    # NOTE: (jpd) these are age limits for the availability of WHO reference data
+    for {age_limit, age, label, available, unavailable} <- [
+          {60, 90, "head circumference unavailable", ~w(chart-height chart-weight chart-bmi),
+           ~w(chart-hc)},
+          {120, 150, "weight and head circumference unavailable", ~w(chart-height chart-bmi),
+           ~w(chart-weight chart-hc)},
+          {228, 240, "all indicators unavailable", [],
+           ~w(chart-height chart-weight chart-bmi chart-hc)}
+        ] do
+      test "over #{age_limit} months renders with #{label}", %{conn: conn} do
+        {:ok, view, _html} = live(conn, ~p"/")
 
-    test "over 120 months renders with weight and head circumference unavailable",
-         %{conn: conn} do
-      assert_renders_for_age(conn, 180,
-        available: ~w(chart-height chart-bmi),
-        unavailable: ~w(chart-weight chart-hc)
-      )
-    end
+        view
+        |> form("#child-form", child: valid_child_attrs(unquote(age)))
+        |> render_submit()
 
-    test "over 228 months renders with all indicators unavailable", %{conn: conn} do
-      assert_renders_for_age(conn, 240,
-        available: [],
-        unavailable: ~w(chart-height chart-weight chart-bmi chart-hc)
-      )
+        html =
+          view
+          |> form("#measure-form", measure: valid_measure_attrs())
+          |> render_submit()
+
+        # Core regression: the results step is reached without raising. The reset
+        # button is always present on the results page; individual charts may be
+        # omitted when their reference data is out of range.
+        assert has_element?(view, "#reset-btn")
+        refute html =~ "BadMapError"
+
+        for id <- unquote(available) do
+          chart = decode_chart_data(view, id)
+          assert chart["labels"] != [], "expected reference data for ##{id} but labels were empty"
+        end
+
+        for id <- unquote(unavailable) do
+          refute has_element?(view, "##{id}"),
+                 "expected ##{id} to be absent (no reference data) but it was rendered"
+        end
+
+        assert html =~ "Indisponível para a idade",
+               "expected an unavailability note for out-of-range indicators"
+      end
     end
   end
 
@@ -203,12 +227,6 @@ defmodule GrowthWeb.GrowthLiveTest do
     end
   end
 
-  defp advance_to_measure_step(view) do
-    view
-    |> form("#child-form", child: valid_child_attrs())
-    |> render_submit()
-  end
-
   defp advance_to_results_step(view) do
     advance_to_measure_step(view)
 
@@ -217,61 +235,10 @@ defmodule GrowthWeb.GrowthLiveTest do
     |> render_submit()
   end
 
-  # Submits a child of the given age (in months) plus measurements, then asserts
-  # the results step renders without crashing and that each chart either carries
-  # reference data or is empty, matching the WHO availability for that age.
-  defp assert_renders_for_age(conn, age_in_months, available: available, unavailable: unavailable) do
-    {:ok, view, _html} = live(conn, ~p"/")
-
+  defp advance_to_measure_step(view) do
     view
-    |> form("#child-form", child: child_attrs_for_age(age_in_months))
+    |> form("#child-form", child: valid_child_attrs())
     |> render_submit()
-
-    html =
-      view
-      |> form("#measure-form", measure: measure_attrs_for_age())
-      |> render_submit()
-
-    # Core regression: the results step is reached without raising.
-    assert has_element?(view, "#chart-height")
-    refute html =~ "BadMapError"
-
-    for id <- available, do: assert_chart_has_reference(view, id)
-    for id <- unavailable, do: refute_chart_has_reference(view, id)
-  end
-
-  defp child_attrs_for_age(age_in_months) do
-    %{
-      "name" => "Jane Doe",
-      "gender" => "female",
-      "birthday" => birthday_months_ago(age_in_months)
-    }
-  end
-
-  defp measure_attrs_for_age do
-    %{"height" => "100", "weight" => "20", "head_circumference" => "50"}
-  end
-
-  # measure_date defaults to today, so age is derived from this birthday. A
-  # small day buffer keeps floor'd age_in_months comfortably in its bucket.
-  defp birthday_months_ago(months) do
-    Date.utc_today()
-    |> Date.add(-trunc(months * 30.4375 + 5))
-    |> Date.to_iso8601()
-  end
-
-  defp assert_chart_has_reference(view, id) do
-    chart = decode_chart_data(view, id)
-
-    assert chart["labels"] != [],
-           "expected reference data for ##{id} but labels were empty"
-  end
-
-  defp refute_chart_has_reference(view, id) do
-    chart = decode_chart_data(view, id)
-
-    assert chart["labels"] == [],
-           "expected no reference data for ##{id} but found #{length(chart["labels"])} points"
   end
 
   # HEEx HTML-escapes JSON in attributes ("  -> &quot;), so we unescape before Jason.decode!
@@ -291,20 +258,28 @@ defmodule GrowthWeb.GrowthLiveTest do
     |> Jason.decode!()
   end
 
-  defp valid_child_attrs do
+  defp valid_child_attrs(age_in_months \\ 24) do
     %{
       "name" => "Jane Doe",
       "gender" => "female",
-      "birthday" => Date.utc_today() |> Date.add(-365 * 2) |> Date.to_iso8601()
+      "birthday" => birthday_months_ago(age_in_months)
     }
   end
 
-  defp invalid_child_attrs do
+  defp invalid_child_attrs(age_in_months \\ 24) do
     %{
       "name" => "An",
       "gender" => "female",
-      "birthday" => Date.utc_today() |> Date.add(-365 * 2) |> Date.to_iso8601()
+      "birthday" => birthday_months_ago(age_in_months)
     }
+  end
+
+  # measure_date defaults to today, so age is derived from this birthday. A
+  # small day buffer keeps floor'd age_in_months comfortably in its bucket.
+  defp birthday_months_ago(months) do
+    Date.utc_today()
+    |> Date.add(-trunc(months * 30.4375 + 5))
+    |> Date.to_iso8601()
   end
 
   defp valid_measure_attrs do

--- a/test/growth_web/live/growth_live_test.exs
+++ b/test/growth_web/live/growth_live_test.exs
@@ -116,7 +116,7 @@ defmodule GrowthWeb.GrowthLiveTest do
   end
 
   describe "save_measure" do
-    test "happy: advances to results step with populated chart data", %{conn: conn} do
+    test "advances to results step with populated chart data", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/")
       advance_to_measure_step(view)
 
@@ -147,7 +147,7 @@ defmodule GrowthWeb.GrowthLiveTest do
       end
     end
 
-    test "zoi-invalid: stays on measure step and renders error when height is negative", %{
+    test "stays on measure step and renders error when height is negative", %{
       conn: conn
     } do
       {:ok, view, _html} = live(conn, ~p"/")
@@ -162,6 +162,28 @@ defmodule GrowthWeb.GrowthLiveTest do
 
       assert has_element?(view, "#measure-form p.text-error")
       assert render(view) =~ "too small: must be at least 0"
+    end
+
+    test "over 60 months renders with head circumference unavailable", %{conn: conn} do
+      assert_renders_for_age(conn, 90,
+        available: ~w(chart-height chart-weight chart-bmi),
+        unavailable: ~w(chart-hc)
+      )
+    end
+
+    test "over 120 months renders with weight and head circumference unavailable",
+         %{conn: conn} do
+      assert_renders_for_age(conn, 180,
+        available: ~w(chart-height chart-bmi),
+        unavailable: ~w(chart-weight chart-hc)
+      )
+    end
+
+    test "over 228 months renders with all indicators unavailable", %{conn: conn} do
+      assert_renders_for_age(conn, 240,
+        available: [],
+        unavailable: ~w(chart-height chart-weight chart-bmi chart-hc)
+      )
     end
   end
 
@@ -193,6 +215,63 @@ defmodule GrowthWeb.GrowthLiveTest do
     view
     |> form("#measure-form", measure: valid_measure_attrs())
     |> render_submit()
+  end
+
+  # Submits a child of the given age (in months) plus measurements, then asserts
+  # the results step renders without crashing and that each chart either carries
+  # reference data or is empty, matching the WHO availability for that age.
+  defp assert_renders_for_age(conn, age_in_months, available: available, unavailable: unavailable) do
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    view
+    |> form("#child-form", child: child_attrs_for_age(age_in_months))
+    |> render_submit()
+
+    html =
+      view
+      |> form("#measure-form", measure: measure_attrs_for_age())
+      |> render_submit()
+
+    # Core regression: the results step is reached without raising.
+    assert has_element?(view, "#chart-height")
+    refute html =~ "BadMapError"
+
+    for id <- available, do: assert_chart_has_reference(view, id)
+    for id <- unavailable, do: refute_chart_has_reference(view, id)
+  end
+
+  defp child_attrs_for_age(age_in_months) do
+    %{
+      "name" => "Jane Doe",
+      "gender" => "female",
+      "birthday" => birthday_months_ago(age_in_months)
+    }
+  end
+
+  defp measure_attrs_for_age do
+    %{"height" => "100", "weight" => "20", "head_circumference" => "50"}
+  end
+
+  # measure_date defaults to today, so age is derived from this birthday. A
+  # small day buffer keeps floor'd age_in_months comfortably in its bucket.
+  defp birthday_months_ago(months) do
+    Date.utc_today()
+    |> Date.add(-trunc(months * 30.4375 + 5))
+    |> Date.to_iso8601()
+  end
+
+  defp assert_chart_has_reference(view, id) do
+    chart = decode_chart_data(view, id)
+
+    assert chart["labels"] != [],
+           "expected reference data for ##{id} but labels were empty"
+  end
+
+  defp refute_chart_has_reference(view, id) do
+    chart = decode_chart_data(view, id)
+
+    assert chart["labels"] == [],
+           "expected no reference data for ##{id} but found #{length(chart["labels"])} points"
   end
 
   # HEEx HTML-escapes JSON in attributes ("  -> &quot;), so we unescape before Jason.decode!


### PR DESCRIPTION
The WHO growth [child][child] and [adolescents][adolescents] reference data is available for different age ranges, as shown below:

| Measure | Age (years) |
|-----|-----|
| Head circumference | [birth to 5][hc1] |
| Weight | [birth to 5][w1] / [5 to 10][w2] |
| Height | [birth to 5][h1] / [5 to 19][h2] |
| BMI | [birth to 5][bmi1] / [5 to 19][bmi2] |

To avoid errors due to those limits or missing data, the results now have a mark (`available?`) that indicates whether the measure or reference data is available. This is used to render classification and graphs conditionally.

[child]: https://www.who.int/tools/child-growth-standards/standards
[adolescents]: https://www.who.int/tools/growth-reference-data-for-5to19-years
[hc1]: https://www.who.int/tools/child-growth-standards/standards/head-circumference-for-age
[w1]: https://www.who.int/tools/child-growth-standards/standards/weight-for-age
[W2]: https://www.who.int/tools/growth-reference-data-for-5to19-years/indicators/weight-for-age-5to10-years
[h1]: https://www.who.int/tools/child-growth-standards/standards/length-height-for-age
[h2]: https://www.who.int/tools/growth-reference-data-for-5to19-years/indicators/height-for-age
[bmi1]: https://www.who.int/toolkits/child-growth-standards/standards/body-mass-index-for-age-bmi-for-age
[bmi2]: https://www.who.int/tools/growth-reference-data-for-5to19-years/indicators/bmi-for-age